### PR TITLE
ダークモード対応,SNSリンクホバー/クリック時の効果を追加

### DIFF
--- a/components/SnsLinks.tsx
+++ b/components/SnsLinks.tsx
@@ -10,10 +10,10 @@ const SnsLink: FC = () => {
         {url: "https://ci-en.dlsite.com/creator/5868", label: "Ci-en"},
     ]
     return (
-        <div className="fixed bottom-0 left-0 w-full h-20 bg-slate-50 z-10">
+        <div className="fixed bottom-0 left-0 w-full h-20 bg-slate-200 z-10 dark:bg-zinc-800">
             <div className="flex justify-center items-center h-full">
                 {snsLinks.map((snslink) => <a key={snslink.url} href={snslink.url} target="_blank"
-                                              rel="noopener noreferrer" className="ml-4">{snslink.label}</a>)}
+                                              rel="noopener noreferrer" className="ml-4 dark:text-gray-100 px-3 py-1 rounded-md duration-100 ease-out hover:bg-gray-300 dark:hover:bg-zinc-700 active:scale-95">{snslink.label}</a>)}
             </div>
         </div>
     );

--- a/components/SnsLinks.tsx
+++ b/components/SnsLinks.tsx
@@ -13,7 +13,7 @@ const SnsLink: FC = () => {
         <div className="fixed bottom-0 left-0 w-full h-20 bg-slate-200 z-10 dark:bg-zinc-800">
             <div className="flex justify-center items-center h-full">
                 {snsLinks.map((snslink) => <a key={snslink.url} href={snslink.url} target="_blank"
-                                              rel="noopener noreferrer" className="ml-4 dark:text-gray-100 px-3 py-1 rounded-md duration-100 ease-out hover:bg-gray-300 dark:hover:bg-zinc-700 active:scale-95">{snslink.label}</a>)}
+                                              rel="noopener noreferrer" className="dark:text-gray-100 px-2 py-1 rounded-md duration-100 ease-out hover:bg-gray-300 dark:hover:bg-zinc-700 active:scale-95">{snslink.label}</a>)}
             </div>
         </div>
     );

--- a/components/profile/Profile.tsx
+++ b/components/profile/Profile.tsx
@@ -4,17 +4,17 @@ import Image from "next/image";
 const Profile: FC = () => {
     return (
         <>
-            <div className="fixed flex flex-wrap justify-center items-center w-full h-screen text-4xl lg:text-8xl font-bold text-slate-500 z-10">
-                Ｉｘｙ（いくしー）
-            </div>
-            <div className="fixed flex flex-wrap justify-center items-center w-full h-screen text-4xl lg:text-8xl font-bold text-slate-500 z-10">
+            <div className="fixed flex flex-wrap flex-col justify-center items-center w-full h-screen text-4xl lg:text-8xl font-bold text-slate-500 z-10">
                 <Image
                     src="/icon.jpeg"
                     width={150}
                     height={150}
-                    className="mb-80 rounded-full"
+                    className="rounded-full mb-8"
                     alt="illustration"
                 />
+                <span className="dark:text-gray-300">
+                  Ｉｘｙ（いくしー）
+                </span>
             </div>
         </>
     );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,7 +8,7 @@ export default function Home() {
     return (
         <>
             <CommonMeta></CommonMeta>
-            <div className="min-h-screen bg-slate-50">
+            <div className="min-h-screen bg-slate-50 dark:bg-zinc-900">
                 <Profile></Profile>
                 <ImageBoard></ImageBoard>
                 <SnsLink></SnsLink>


### PR DESCRIPTION
# 変更内容
 - Tailwindを使ってデバイスの設定に応じてダークモードになるようにしました。
 - SNSのリンクをホバーしたときに背景色が少し変わるようにしました。
 - SNSのリンクをクリックしたときにリンクが小さくなるようにしました
 - SNSLinksの背景色を少し変更しました
 - アイコンと名前が別々のdivタグに入っていたので一緒のdivタグに入れてまとめて中央寄せをするようにしました。
# 変更前/後のスクリーンショット
Firefox 110.0b9 (64-bit)で確認しました。
クリックでファイルを開けます。

<table>
<tr>
	<td></td>
	<td>ライトモード</td>
	<td>ダークモード</td>
<tr>
	<td>変更前</td>
	<td><img src="https://user-images.githubusercontent.com/121326808/227762675-d98d3da3-5548-4f04-8c44-a6ccc9031053.png"/></td>
	<td>なし</td>
<tr>
	<td>変更後</td>
	<td><img src="https://user-images.githubusercontent.com/121326808/227762438-26c72241-7a0e-4543-baea-7b47060db223.png"/></td>
	<td><img src="https://user-images.githubusercontent.com/121326808/227762605-13be60f4-7cac-45a5-abde-8c52072a366f.png"/></td>
</table>