### PR TITLE
フッターをすりガラス風に; 文字サイズの調整

### DIFF
--- a/__test__/components/profile/Profile.test.tsx
+++ b/__test__/components/profile/Profile.test.tsx
@@ -1,11 +1,11 @@
-import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
-import Profile from "../../../components/profile/Profile";
+import '@testing-library/jest-dom';
+import { render, screen, within } from '@testing-library/react';
+import Profile from '../../../components/profile/Profile';
 
-describe("Profile", () => {
-    test("Profile名が表示されているか", () => {
-        render(<Profile />);
-        const text = screen.getByText("Ｉｘｙ（いくしー）");
-        expect(text).toBeInTheDocument();
-    });
+describe('Profile', () => {
+  test('Profile名が表示されているか', () => {
+    render(<Profile />);
+    const { getByText } = within(screen.getByText('Ｉｘｙ'));
+    expect(getByText('いくしー')).toBeInTheDocument();
+  });
 });

--- a/components/SnsLinks.tsx
+++ b/components/SnsLinks.tsx
@@ -10,7 +10,7 @@ const SnsLink: FC = () => {
     { url: 'https://ci-en.dlsite.com/creator/5868', label: 'Ci-en' },
   ];
   return (
-    <div className="absolute bottom-0 left-0 w-full h-20 bg-white/10 dark:bg-black/10 backdrop-blur-md shadow-[inset_0_32px_32px_-32px_rgba(255,255,255,0.4)] z-10">
+    <div className="absolute bottom-0 left-0 w-full h-20 bg-white/10 dark:bg-black/10 backdrop-blur-md shadow-[inset_0_32px_32px_-32px_rgba(255,255,255,0.4)] z-30">
       <div className="flex justify-center items-center h-full">
         {snsLinks.map((snslink) => (
           <a

--- a/components/SnsLinks.tsx
+++ b/components/SnsLinks.tsx
@@ -1,22 +1,31 @@
-import {FC} from 'react';
-import {SnsLink} from "../types/SnsLink"
+import { FC } from 'react';
+import { SnsLink } from '../types/SnsLink';
 
 const SnsLink: FC = () => {
-    const snsLinks: Array<SnsLink> = [
-        {url: "https://twitter.com/Ixy", label: "Twitter"},
-        {url: "https://www.instagram.com/ixy__194/?hl=ja", label: "Instagram"},
-        {url: "https://www.youtube.com/@ixy", label: "YouTube"},
-        {url: "https://ixy.fanbox.cc/", label: "fanbox"},
-        {url: "https://ci-en.dlsite.com/creator/5868", label: "Ci-en"},
-    ]
-    return (
-        <div className="fixed bottom-0 left-0 w-full h-20 bg-slate-200 z-10 dark:bg-zinc-800">
-            <div className="flex justify-center items-center h-full">
-                {snsLinks.map((snslink) => <a key={snslink.url} href={snslink.url} target="_blank"
-                                              rel="noopener noreferrer" className="dark:text-gray-100 px-2 py-1 rounded-md duration-100 ease-out hover:bg-gray-300 dark:hover:bg-zinc-700 active:scale-95">{snslink.label}</a>)}
-            </div>
-        </div>
-    );
+  const snsLinks: Array<SnsLink> = [
+    { url: 'https://twitter.com/Ixy', label: 'Twitter' },
+    { url: 'https://www.instagram.com/ixy__194/?hl=ja', label: 'Instagram' },
+    { url: 'https://www.youtube.com/@ixy', label: 'YouTube' },
+    { url: 'https://ixy.fanbox.cc/', label: 'fanbox' },
+    { url: 'https://ci-en.dlsite.com/creator/5868', label: 'Ci-en' },
+  ];
+  return (
+    <div className="absolute bottom-0 left-0 w-full h-20 bg-white/10 backdrop-blur-md shadow-[inset_0_32px_32px_-32px_rgba(255,255,255,0.4)] shadow-white z-10">
+      <div className="flex justify-center items-center h-full">
+        {snsLinks.map((snslink) => (
+          <a
+            key={snslink.url}
+            href={snslink.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="dark:text-gray-100 px-2 py-1 rounded-md duration-100 ease-out hover:bg-gray-300 dark:hover:bg-zinc-700 active:scale-95"
+          >
+            {snslink.label}
+          </a>
+        ))}
+      </div>
+    </div>
+  );
 };
 
-export default SnsLink
+export default SnsLink;

--- a/components/SnsLinks.tsx
+++ b/components/SnsLinks.tsx
@@ -10,7 +10,7 @@ const SnsLink: FC = () => {
     { url: 'https://ci-en.dlsite.com/creator/5868', label: 'Ci-en' },
   ];
   return (
-    <div className="absolute bottom-0 left-0 w-full h-20 bg-white/10 dark:bg-black/10 backdrop-blur-md shadow-[inset_0_32px_32px_-32px_rgba(255,255,255,0.4)] z-30">
+    <div className="absolute bottom-0 left-0 w-full h-20 bg-white/10 dark:bg-black/10 backdrop-blur-md shadow-[inset_0_32px_32px_-32px_rgba(255,255,255,0.8)] z-30">
       <div className="flex justify-center items-center h-full">
         {snsLinks.map((snslink) => (
           <a

--- a/components/SnsLinks.tsx
+++ b/components/SnsLinks.tsx
@@ -10,7 +10,7 @@ const SnsLink: FC = () => {
     { url: 'https://ci-en.dlsite.com/creator/5868', label: 'Ci-en' },
   ];
   return (
-    <div className="absolute bottom-0 left-0 w-full h-20 bg-white/10 backdrop-blur-md shadow-[inset_0_32px_32px_-32px_rgba(255,255,255,0.4)] shadow-white z-10">
+    <div className="absolute bottom-0 left-0 w-full h-20 bg-white/10 dark:bg-black/10 backdrop-blur-md shadow-[inset_0_32px_32px_-32px_rgba(255,255,255,0.4)] z-10">
       <div className="flex justify-center items-center h-full">
         {snsLinks.map((snslink) => (
           <a

--- a/components/SnsLinks.tsx
+++ b/components/SnsLinks.tsx
@@ -18,7 +18,7 @@ const SnsLink: FC = () => {
             href={snslink.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="dark:text-gray-100 px-2 py-1 rounded-md duration-100 ease-out hover:bg-gray-300 dark:hover:bg-zinc-700 active:scale-95"
+            className="dark:text-gray-100 px-2 py-1 rounded-md duration-100 ease-out hover:bg-white/10 active:scale-95"
           >
             {snslink.label}
           </a>

--- a/components/SnsLinks.tsx
+++ b/components/SnsLinks.tsx
@@ -18,7 +18,7 @@ const SnsLink: FC = () => {
             href={snslink.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="dark:text-gray-100 px-2 py-1 rounded-md duration-100 ease-out hover:bg-white/10 active:scale-95"
+            className="dark:text-gray-100 px-2 py-1 rounded-md duration-100 ease-out hover:bg-slate-400/10 dark:hover:bg-white/10 active:scale-95"
           >
             {snslink.label}
           </a>

--- a/components/profile/Profile.tsx
+++ b/components/profile/Profile.tsx
@@ -1,23 +1,24 @@
-import { FC } from "react";
-import Image from "next/image";
+import { FC } from 'react';
+import Image from 'next/image';
 
 const Profile: FC = () => {
-    return (
-        <>
-            <div className="fixed flex flex-wrap flex-col justify-center items-center w-full h-screen text-4xl lg:text-8xl font-bold text-slate-500 z-10">
-                <Image
-                    src="/icon.jpeg"
-                    width={150}
-                    height={150}
-                    className="rounded-full mb-8"
-                    alt="illustration"
-                />
-                <span className="dark:text-gray-300">
-                  Ｉｘｙ（いくしー）
-                </span>
-            </div>
-        </>
-    );
+  return (
+    <>
+      <div className="fixed flex flex-wrap flex-col justify-center items-center w-full h-screen text-4xl lg:text-8xl font-bold text-slate-500 z-10">
+        <Image
+          src="/icon.jpeg"
+          width={150}
+          height={150}
+          className="rounded-full mb-8"
+          alt="illustration"
+        />{' '}
+        <div>
+          Ｉｘｙ
+          <span className="text-5xl">いくしー</span>
+        </div>
+      </div>
+    </>
+  );
 };
 
 export default Profile;

--- a/components/profile/Profile.tsx
+++ b/components/profile/Profile.tsx
@@ -4,14 +4,14 @@ import Image from 'next/image';
 const Profile: FC = () => {
   return (
     <>
-      <div className="fixed flex flex-wrap flex-col justify-center items-center w-full h-screen text-4xl lg:text-8xl font-bold text-slate-500 z-10">
+      <div className="fixed flex flex-wrap flex-col justify-center items-center w-full h-screen text-4xl lg:text-8xl font-bold text-slate-500 z-20">
         <Image
           src="/icon.jpeg"
           width={150}
           height={150}
           className="rounded-full mb-8"
           alt="illustration"
-        />{' '}
+        />
         <div>
           Ｉｘｙ
           <span className="text-5xl">いくしー</span>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,17 +2,17 @@ import Head from 'next/head';
 import ImageBoard from '../components/imagecard/ImageBoard';
 import SnsLink from '../components/SnsLinks';
 import Profile from '../components/profile/Profile';
-import CommonMeta from '../components/CommonMeta'
+import CommonMeta from '../components/CommonMeta';
 
 export default function Home() {
-    return (
-        <>
-            <CommonMeta></CommonMeta>
-            <div className="min-h-screen bg-slate-50 dark:bg-zinc-900">
-                <Profile></Profile>
-                <ImageBoard></ImageBoard>
-                <SnsLink></SnsLink>
-            </div>
-        </>
-    );
+  return (
+    <>
+      <CommonMeta></CommonMeta>
+      <div className="min-h-screen bg-slate-50 dark:bg-zinc-900">
+        <Profile></Profile>
+        <ImageBoard></ImageBoard>
+        <SnsLink></SnsLink>
+      </div>
+    </>
+  );
 }


### PR DESCRIPTION
- 文字サイズが微妙だったので、直しました
- 重なり順がおかしくなっていたので、背景が後ろになるようにしました
- フッター（？）をすりガラス風にしてみました
- コンマの削除

変更前
<img width="1920" alt="スクリーンショット 2023-03-27 8 42 57" src="https://user-images.githubusercontent.com/86896657/227812289-fb56b962-944c-4d66-830d-ff156ae93fe9.png">

変更後
<img width="961" alt="スクリーンショット 2023-03-27 11 44 32" src="https://user-images.githubusercontent.com/86896657/227828118-7e5f4ebe-f681-48d2-8c59-b53a9e6f99c1.png">

