### PR TITLE
名前（ひらがな部分）を下に移動して横に線をつけた

### DIFF
--- a/__test__/components/profile/Profile.test.tsx
+++ b/__test__/components/profile/Profile.test.tsx
@@ -11,6 +11,6 @@ describe("Profile", () => {
     test("Profile名(ひらがな)が表示されているか", () => {
         render(<Profile />);
         const text_ruby = screen.getByText("いくしー");
-        expect(text).toBeInTheDocument();
+        expect(text_ruby).toBeInTheDocument();
     });
 });

--- a/__test__/components/profile/Profile.test.tsx
+++ b/__test__/components/profile/Profile.test.tsx
@@ -5,7 +5,12 @@ import Profile from "../../../components/profile/Profile";
 describe("Profile", () => {
     test("Profile名が表示されているか", () => {
         render(<Profile />);
-        const text = screen.getByText("Ｉｘｙ（いくしー）");
+        const text = screen.getByText("Ｉｘｙ");
+        expect(text).toBeInTheDocument();
+    });
+    test("Profile名(ひらがな)が表示されているか", () => {
+        render(<Profile />);
+        const text_ruby = screen.getByText("いくしー");
         expect(text).toBeInTheDocument();
     });
 });

--- a/components/profile/Profile.tsx
+++ b/components/profile/Profile.tsx
@@ -17,9 +17,9 @@ const Profile: FC = () => {
                   Ｉｘｙ
                 </span>
                 <div className="grid grid-cols-3 items-center justify-center mt-3">
-                  <hr width="100%" className="border-slate-400 dark:border-gray-400"/>
+                  <hr className="w-full border-slate-400 dark:border-gray-400"/>
                   <span className="mx-3 text-xl text-slate-500 dark:text-gray-300">いくしー</span>
-                  <hr width="100%" className="border-slate-400 dark:border-gray-400"/>
+                  <hr className="w-full border-slate-400 dark:border-gray-400"/>
                 </div>
               </div>
            </div>

--- a/components/profile/Profile.tsx
+++ b/components/profile/Profile.tsx
@@ -12,10 +12,17 @@ const Profile: FC = () => {
                     className="rounded-full mb-8"
                     alt="illustration"
                 />
+              <div className="flex justify-center flex-col items-center">
                 <span className="dark:text-gray-300">
-                  Ｉｘｙ（いくしー）
+                  Ｉｘｙ
                 </span>
-            </div>
+                <div className="grid grid-cols-3 items-center justify-center mt-3">
+                  <hr width="100%" className="border-slate-400 dark:border-gray-400"/>
+                  <span className="mx-3 text-xl text-slate-500 dark:text-gray-300">いくしー</span>
+                  <hr width="100%" className="border-slate-400 dark:border-gray-400"/>
+                </div>
+              </div>
+           </div>
         </>
     );
 };


### PR DESCRIPTION
# 変更内容
 - プロフィールの名前ひらがな部分（カッコに囲まれている部分）をカッコを取って下に配置
 - ひらがなの横に線を追加して文字と線を中央揃えにした
 - ひらがなを別タグに入れたためテストが失敗するようになったのを調整
# 変更前/後スクリーンショット
Firefox 110.0b9 (64-bit)で確認しました。
クリックでファイルを開けます。
（ライト/ダークモード対応しています）

<table>
<tr>
	<td>前</td>
	<td>後</td>
<tr>
	<td>
<img src="https://user-images.githubusercontent.com/121326808/227828157-6bbb5e77-26dc-4d59-96a4-2d005acc13ab.png"/>
</td>
	<td>
<img src="https://user-images.githubusercontent.com/121326808/227828032-6849e643-4f53-4eb2-9ff7-f2089f17353d.png"/>
</td>
</table>

# その他
- TwitterもGithubもひらがな部分はカッコの中に入れてあるのでもしかしたらこれはやってはいけない変更なのかもしれない
- #30 と文字サイズ変更の部分で少しかぶっているので様子をみて提出したい