### PR TITLE
 フッターをすりガラス風に; 文字サイズの調整（２）

### DIFF
--- a/components/SnsLink.tsx
+++ b/components/SnsLink.tsx
@@ -11,7 +11,7 @@ const SnsLink: FC<SnsLinkProps> = ({ href, children }) => {
 			href={href}
 			target="_blank"
 			rel="noopener noreferrer"
-			className="dark:text-gray-100 px-2 py-1 rounded-md duration-100 ease-out hover:bg-gray-300 dark:hover:bg-zinc-700 active:scale-95"
+			className="dark:text-gray-100 px-2 py-1 rounded-md duration-100 ease-out hover:bg-white/10 active:scale-95"
 		>
 			{children}
 		</a>

--- a/components/SnsLink.tsx
+++ b/components/SnsLink.tsx
@@ -11,7 +11,7 @@ const SnsLink: FC<SnsLinkProps> = ({ href, children }) => {
 			href={href}
 			target="_blank"
 			rel="noopener noreferrer"
-			className="dark:text-gray-100 px-2 py-1 rounded-md duration-100 ease-out hover:bg-white/10 active:scale-95"
+			className="dark:text-gray-100 px-2 py-1 rounded-md duration-100 ease-out hover:bg-slate-400/10 dark:hover:bg-white/10 active:scale-95"
 		>
 			{children}
 		</a>

--- a/components/SnsLinks.tsx
+++ b/components/SnsLinks.tsx
@@ -3,7 +3,7 @@ import SnsLink from './SnsLink';
 
 const SnsLinks: FC = () => {
 	return (
-		<div className="absolute bottom-0 left-0 w-full h-20 bg-white/10 dark:bg-black/10 backdrop-blur-md shadow-[inset_0_32px_32px_-32px_rgba(255,255,255,0.4)] z-30">
+		<div className="absolute bottom-0 left-0 w-full h-20 bg-white/10 dark:bg-black/10 backdrop-blur-md shadow-[inset_0_32px_32px_-32px_rgba(255,255,255,0.8)] z-30">
 			<div className="flex justify-center items-center h-full space-x-4">
 				<SnsLink href="https://twitter.com/Ixy">Twitter</SnsLink>,
 				<SnsLink href="https://www.instagram.com/ixy__194/?hl=ja">Instagram</SnsLink>,

--- a/components/SnsLinks.tsx
+++ b/components/SnsLinks.tsx
@@ -5,11 +5,11 @@ const SnsLinks: FC = () => {
 	return (
 		<div className="absolute bottom-0 left-0 w-full h-20 bg-white/10 dark:bg-black/10 backdrop-blur-md shadow-[inset_0_32px_32px_-32px_rgba(255,255,255,0.8)] z-30">
 			<div className="flex justify-center items-center h-full space-x-4">
-				<SnsLink href="https://twitter.com/Ixy">Twitter</SnsLink>,
-				<SnsLink href="https://www.instagram.com/ixy__194/?hl=ja">Instagram</SnsLink>,
-				<SnsLink href="https://www.youtube.com/@ixy">YouTube</SnsLink>,
-				<SnsLink href="https://ixy.fanbox.cc/">fanbox</SnsLink>,
-				<SnsLink href="https://ci-en.dlsite.com/creator/5868">Ci-en</SnsLink>,
+				<SnsLink href="https://twitter.com/Ixy">Twitter</SnsLink>
+				<SnsLink href="https://www.instagram.com/ixy__194/?hl=ja">Instagram</SnsLink>
+				<SnsLink href="https://www.youtube.com/@ixy">YouTube</SnsLink>
+				<SnsLink href="https://ixy.fanbox.cc/">fanbox</SnsLink>
+				<SnsLink href="https://ci-en.dlsite.com/creator/5868">Ci-en</SnsLink>
 			</div>
 		</div>
 	);

--- a/components/SnsLinks.tsx
+++ b/components/SnsLinks.tsx
@@ -3,7 +3,7 @@ import SnsLink from './SnsLink';
 
 const SnsLinks: FC = () => {
 	return (
-		<div className="absolute bottom-0 left-0 w-full h-20 bg-white/10 backdrop-blur-md shadow-[inset_0_32px_32px_-32px_rgba(255,255,255,0.4)] shadow-white z-10">
+		<div className="absolute bottom-0 left-0 w-full h-20 bg-white/10 dark:bg-black/10 backdrop-blur-md shadow-[inset_0_32px_32px_-32px_rgba(255,255,255,0.4)] z-10">
 			<div className="flex justify-center items-center h-full space-x-4">
 				<SnsLink href="https://twitter.com/Ixy">Twitter</SnsLink>,
 				<SnsLink href="https://www.instagram.com/ixy__194/?hl=ja">Instagram</SnsLink>,

--- a/components/SnsLinks.tsx
+++ b/components/SnsLinks.tsx
@@ -3,7 +3,7 @@ import SnsLink from './SnsLink';
 
 const SnsLinks: FC = () => {
 	return (
-		<div className="fixed bottom-0 left-0 w-full h-20 bg-slate-200 z-10 dark:bg-zinc-800">
+		<div className="absolute bottom-0 left-0 w-full h-20 bg-white/10 backdrop-blur-md shadow-[inset_0_32px_32px_-32px_rgba(255,255,255,0.4)] shadow-white z-10">
 			<div className="flex justify-center items-center h-full space-x-4">
 				<SnsLink href="https://twitter.com/Ixy">Twitter</SnsLink>,
 				<SnsLink href="https://www.instagram.com/ixy__194/?hl=ja">Instagram</SnsLink>,

--- a/components/SnsLinks.tsx
+++ b/components/SnsLinks.tsx
@@ -3,7 +3,7 @@ import SnsLink from './SnsLink';
 
 const SnsLinks: FC = () => {
 	return (
-		<div className="absolute bottom-0 left-0 w-full h-20 bg-white/10 dark:bg-black/10 backdrop-blur-md shadow-[inset_0_32px_32px_-32px_rgba(255,255,255,0.8)] z-30">
+		<div className="absolute bottom-0 left-0 w-full h-20 bg-white/10 dark:bg-black/10 backdrop-blur-md border-t border-t-white/10 z-30">
 			<div className="flex justify-center items-center h-full space-x-4">
 				<SnsLink href="https://twitter.com/Ixy">Twitter</SnsLink>
 				<SnsLink href="https://www.instagram.com/ixy__194/?hl=ja">Instagram</SnsLink>

--- a/components/SnsLinks.tsx
+++ b/components/SnsLinks.tsx
@@ -3,7 +3,7 @@ import SnsLink from './SnsLink';
 
 const SnsLinks: FC = () => {
 	return (
-		<div className="absolute bottom-0 left-0 w-full h-20 bg-white/10 dark:bg-black/10 backdrop-blur-md shadow-[inset_0_32px_32px_-32px_rgba(255,255,255,0.4)] z-10">
+		<div className="absolute bottom-0 left-0 w-full h-20 bg-white/10 dark:bg-black/10 backdrop-blur-md shadow-[inset_0_32px_32px_-32px_rgba(255,255,255,0.4)] z-30">
 			<div className="flex justify-center items-center h-full space-x-4">
 				<SnsLink href="https://twitter.com/Ixy">Twitter</SnsLink>,
 				<SnsLink href="https://www.instagram.com/ixy__194/?hl=ja">Instagram</SnsLink>,

--- a/components/profile/Profile.tsx
+++ b/components/profile/Profile.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 const Profile: FC = () => {
 	return (
 		<>
-			<div className="fixed flex flex-wrap flex-col justify-center items-center w-full h-screen text-4xl lg:text-8xl font-bold text-slate-500 z-20">
+			<div className="fixed flex flex-wrap flex-col justify-center items-center w-full h-screen text-5xl lg:text-7xl font-bold text-slate-500 z-20">
 				<Image
 					src="/icon.jpeg"
 					width={150}

--- a/components/profile/Profile.tsx
+++ b/components/profile/Profile.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 const Profile: FC = () => {
 	return (
 		<>
-			<div className="fixed flex flex-wrap flex-col justify-center items-center w-full h-screen text-4xl lg:text-8xl font-bold text-slate-500 z-10">
+			<div className="fixed flex flex-wrap flex-col justify-center items-center w-full h-screen text-4xl lg:text-8xl font-bold text-slate-500 z-20">
 				<Image
 					src="/icon.jpeg"
 					width={150}


### PR DESCRIPTION
コンフリクト修正したので新しく作りした。すみません...

- 文字サイズが微妙だったので、修正
- 重なり順がおかしくなっていたので、背景が後ろになるようにしました
- フッター（？）をすりガラス風にしてみました
- コンマの削除

変更前
<img width="1915" alt="スクリーンショット 2023-03-31 10 10 56" src="https://user-images.githubusercontent.com/86896657/228998235-ec9ee754-44c1-4c56-867c-97f40e155fe9.png">

変更後
<img width="961" alt="スクリーンショット 2023-03-31 10 13 57" src="https://user-images.githubusercontent.com/86896657/228998177-4d055a13-8f17-4c85-9167-714657f321aa.png">