### PR TITLE
小さい端末以外では左にProfileが寄るようにした/透明度のグラデーションで可読性を上げた

### DIFF
--- a/components/imagecard/ImageLine.tsx
+++ b/components/imagecard/ImageLine.tsx
@@ -8,7 +8,7 @@ export const imageLinePaddingSize = {
 
 const ImageLine: FC<ImageLineProps> = ({ lineArray }) => {
 	return (
-		<div className="relative flex gap-12 opacity-25 px-6 py-8 image-line-anim">
+		<div className="relative flex gap-12 opacity-25 md:opacity-40 px-6 py-8 image-line-anim">
 			{lineArray.map((v, i) => (
 				<div key={i} className="flex h-full justify-between gap-12">
 					{v}

--- a/components/profile/Profile.tsx
+++ b/components/profile/Profile.tsx
@@ -4,21 +4,17 @@ import Image from 'next/image';
 const Profile: FC = () => {
 	return (
 		<>
-			<div className="fixed flex flex-wrap flex-col justify-center items-center w-full h-screen text-5xl lg:text-7xl font-bold text-slate-500 z-20">
+			<div className="flex flex-wrap items-center justify-center md:flex-row flex-col lg:text-7xl font-bold text-slate-500">
 				<Image
 					src="/icon.jpeg"
-					width={150}
-					height={150}
-					className="rounded-full mb-8"
+					width={120}
+					height={120}
+					className="rounded-full md:mb-0 mb-3 md:mr-5 h-max"
 					alt="illustration"
 				/>
-				<div className="flex justify-center flex-col items-center">
-					<span className="dark:text-gray-300">Ｉｘｙ</span>
-					<div className="grid grid-cols-3 items-center justify-center mt-3">
-						<hr className="w-full border-slate-400 dark:border-gray-400" />
-						<span className="mx-3 text-xl text-slate-500 dark:text-gray-300">いくしー</span>
-						<hr className="w-full border-slate-400 dark:border-gray-400" />
-					</div>
+				<div className="flex justify-center items-center md:items-start flex-col">
+					<span className="dark:text-gray-300 font-extrabold text-6xl lg:text-8xl md:drop-shadow-none drop-shadow-lg">Ｉｘｙ</span>
+					<span className="mt-3 items-center w-fit text-xl text-slate-500 dark:text-gray-300 md:ml-6 md:drop-shadow-none drop-shadow-lg">いくしー</span>
 				</div>
 			</div>
 		</>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,7 +10,11 @@ export default function Home() {
 		<>
 			<CommonMeta></CommonMeta>
 			<div className="min-h-screen bg-slate-50 dark:bg-zinc-900">
-				<Profile></Profile>
+        <div className="flex justify-center items-center md:bg-gradient-to-r md:from-slate-50 md:dark:from-zinc-900 md:from-10% fixed w-full h-screen z-20">
+          <div className="flex w-full md:mx-32 md:justify-start justify-center">
+  				  <Profile></Profile>
+          </div>
+        </div>
 				<ImageBoard></ImageBoard>
 				<SnsLink></SnsLink>
 				<Mailto></Mailto>


### PR DESCRIPTION
# 変更内容
 - アイコンを左、名前を右で横並びにした
 - バランスを考えてアイコンを小さくした
 - 文字を中央寄せから左側に寄った位置に配置するようにした（画面がある程度小さい場合中央寄せにした）
	 - 左に寄せることで、右側に要素を追加することができるようになる（追加しなくても割とバランスがよく見える）
 - 背景のImageBoardに透明度のグラデーションをつけて左側を無彩色にして可読性を上げた（画面がある程度小さい場合中央寄せになるから、意味がないので無効）
 - 透明度のグラデーションで文字が読みやすくなったと思うので、ImageLineの透明度を下げてイラストを見やすくした
	 - 画面がある程度小さい場合は、これまでと同じ透明度にして文字にシャドウをつけて見やすくした
 - ふりがなの右と左に線をつけるのをやめた（必要なのか怪しいのと、文字の位置の中央寄せをやめたことであると微妙に見えるようになったため）
# 変更前/後のスクリーンショット
Firefox 112.0b7 (64-bit)で確認しました。
クリックでファイルを開けます。
### 全体
<table>
<tr>
	<td></td>
	<td>ライトモード</td>
	<td>ダークモード</td>
<tr>
	<td>変更前</td>
	<td><img src="https://user-images.githubusercontent.com/121326808/229825679-f9833404-f557-463d-a927-8f1c861d7569.png"/></td>
	<td><img src="https://user-images.githubusercontent.com/121326808/229825583-a787517f-ae48-4805-b250-2c6b9a0f9170.png"/></td>
<tr>
	<td>変更後</td>
	<td><img src="https://user-images.githubusercontent.com/121326808/229824225-a98aab28-87a4-4aae-9def-ae09a1040a89.png"/></td>
	<td><img src="https://user-images.githubusercontent.com/121326808/229823707-1807c249-eb7d-49d2-94a3-9096bdc809d0.png"/></td>
</table>

### 画面サイズ

<table>
	<td>変更前</td>
	<td>変更後</td>
<tr>
	<td><img src="https://user-images.githubusercontent.com/121326808/229826484-265860f7-b091-4253-841a-0294f9262442.png"/></td>
	<td><img src="https://user-images.githubusercontent.com/121326808/229826696-27852aad-6f2f-4c2d-84b6-bd9e32f57fb0.png"/></td>
</table>